### PR TITLE
Make DNS Claim work and disable-able. Use mac api calls for bundle directory detection

### DIFF
--- a/lokicp.pro
+++ b/lokicp.pro
@@ -22,7 +22,7 @@ HEADERS += src/QmlClipboardAdapter.hpp \
 RESOURCES += res/resources.qrc
 
 macx {
-    LIBS += -framework Security
+    LIBS += -framework Security -framework CoreFoundation
     HEADERS += src/process/MacOSLokinetProcessManager.hpp
     SOURCES += src/process/MacOSLokinetProcessManager.cpp
 }

--- a/src/process/MacOSLokinetProcessManager.cpp
+++ b/src/process/MacOSLokinetProcessManager.cpp
@@ -7,6 +7,17 @@
 
 #ifdef Q_OS_MACOS
 
+#define LOKINET_BINARY_NAME    "lokinet"
+
+// these paths are all relative to the app bundle root
+#define BINARY_PATH            "Contents/MacOS/"
+#define DNS_CLAIM_FILEPATH     BINARY_PATH "/dns_claim.sh"
+#define DNS_UNCLAIM_FILEPATH   BINARY_PATH "/dns_unclaim.sh"
+#define LOKINET_FILEPATH       BINARY_PATH "/" LOKINET_BINARY_NAME
+
+#define RESOURCES_PATH         "Contents/Resources/"
+#define DISABLE_DNS_FILE       RESOURCES_PATH "/disable_auto_dns"
+
 // utility to run a process as root
 // Note that 'args' should be NULL-terminated
 bool sudo(const std::string& cmd, const char* args[])
@@ -40,7 +51,7 @@ MacOSLokinetProcessManager::~MacOSLokinetProcessManager()
 
 bool MacOSLokinetProcessManager::claimDNS()
 {
-    int result = system("dns_claim.sh");
+    int result = system(DNS_CLAIM_FILEPATH);
     if (result)
         qDebug() << "warning: failed to claim dns: " << result;
     else
@@ -51,7 +62,7 @@ bool MacOSLokinetProcessManager::claimDNS()
 
 bool MacOSLokinetProcessManager::unclaimDNS()
 {
-    int result = system("dns_unclaim.sh");
+    int result = system(DNS_UNCLAIM_FILEPATH);
     if (result)
         qDebug() << "warning: failed to unclaim dns: " << result;
     else
@@ -66,7 +77,7 @@ bool MacOSLokinetProcessManager::doStartLokinetProcess()
     if (! success)
         qDebug("dns claim failed, starting lokinet anyway");
 
-    success = sudo("lokinet", {NULL});
+    success = sudo(LOKINET_FILEPATH, {NULL});
     if (! success)
         qDebug("failed to launch lokinet via AuthorizationExecuteWithPrivileges");
 
@@ -79,7 +90,7 @@ bool MacOSLokinetProcessManager::doStopLokinetProcess()
     if (! success)
         qDebug("dns unclaim failed, killing lokinet anyway");
 
-    const char* args[] = {"lokinet", NULL};
+    const char* args[] = {LOKINET_BINARY_NAME, NULL};
     success = sudo("/usr/bin/killall", args);
     if (! success)
         qDebug("failed to launch lokinet via AuthorizationExecuteWithPrivileges");
@@ -89,7 +100,7 @@ bool MacOSLokinetProcessManager::doStopLokinetProcess()
 
 bool MacOSLokinetProcessManager::doForciblyStopLokinetProcess()
 {
-    const char* args[] = {"-9", "lokinet", NULL};
+    const char* args[] = {"-9", LOKINET_BINARY_NAME, NULL};
     bool success = sudo("/usr/bin/killall", args);
     if (! success)
         qDebug("failed to launch lokinet via AuthorizationExecuteWithPrivileges");
@@ -101,7 +112,7 @@ bool MacOSLokinetProcessManager::doGetProcessPid(int& pid)
 {
     QProcess proc;
     proc.setProgram("pgrep");
-    proc.setArguments({"lokinet"});
+    proc.setArguments({LOKINET_BINARY_NAME});
     proc.start();
     bool success = proc.waitForFinished(5000);
     if (!success)

--- a/src/process/MacOSLokinetProcessManager.cpp
+++ b/src/process/MacOSLokinetProcessManager.cpp
@@ -7,6 +7,8 @@
 
 #ifdef Q_OS_MACOS
 
+#include "CoreFoundation/CoreFoundation.h"
+
 #define LOKINET_BINARY_NAME    "lokinet"
 
 // these paths are all relative to the app bundle root
@@ -17,6 +19,20 @@
 
 #define RESOURCES_PATH         "Contents/Resources/"
 #define DISABLE_DNS_FILE       RESOURCES_PATH "/disable_auto_dns"
+
+void resetMacPwd() {
+    CFBundleRef mainBundle = CFBundleGetMainBundle();
+    CFURLRef resourcesURL = CFBundleCopyResourcesDirectoryURL(mainBundle);
+    char path[PATH_MAX];
+    if (!CFURLGetFileSystemRepresentation(resourcesURL, TRUE, (UInt8 *)path, PATH_MAX))
+    {
+        qDebug("Couldn't reset mac PWD, good luck");
+    }
+    CFRelease(resourcesURL);
+
+    chdir(path);
+    qDebug() << "Current Path: " << path;
+}
 
 // utility to run a process as root
 // Note that 'args' should be NULL-terminated

--- a/src/process/MacOSLokinetProcessManager.cpp
+++ b/src/process/MacOSLokinetProcessManager.cpp
@@ -146,12 +146,12 @@ bool MacOSLokinetProcessManager::doStartLokinetProcess()
 bool MacOSLokinetProcessManager::doStopLokinetProcess()
 {
     const char* args[] = {LOKINET_BINARY_NAME, NULL};
-    success = sudo("/usr/bin/killall", args);
+    bool success = sudo("/usr/bin/killall", args);
     if (not success) {
         qDebug("failed to kill lokinet via AuthorizationExecuteWithPrivileges");
         return false;
     }
-    bool success = unclaimDNS();
+    success = unclaimDNS();
     if (not success)
         qDebug("dns unclaim failed, killing lokinet anyway");
 

--- a/src/process/MacOSLokinetProcessManager.hpp
+++ b/src/process/MacOSLokinetProcessManager.hpp
@@ -15,10 +15,11 @@ class MacOSLokinetProcessManager : public LokinetProcessManager
     Q_OBJECT
 
 public:
+    MacOSLokinetProcessManager();
     ~MacOSLokinetProcessManager();
 
 protected:
-    
+
     bool doStartLokinetProcess() override;
     bool doStopLokinetProcess() override;
     bool doForciblyStopLokinetProcess() override;
@@ -28,7 +29,8 @@ private:
 
     bool claimDNS();
     bool unclaimDNS();
-    
+
+    bool m_dnsClaimEnabled = true;
     bool m_dnsClaimed = false;
 };
 

--- a/src/process/MacOSLokinetProcessManager.hpp
+++ b/src/process/MacOSLokinetProcessManager.hpp
@@ -14,6 +14,9 @@ class MacOSLokinetProcessManager : public LokinetProcessManager
 {
     Q_OBJECT
 
+public:
+    ~MacOSLokinetProcessManager();
+
 protected:
     
     bool doStartLokinetProcess() override;
@@ -21,6 +24,12 @@ protected:
     bool doForciblyStopLokinetProcess() override;
     bool doGetProcessPid(int& pid) override;
 
+private:
+
+    bool claimDNS();
+    bool unclaimDNS();
+    
+    bool m_dnsClaimed = false;
 };
 
 #endif // __LOKI_MACOS_LOKINET_PROCESS_MANAGER_HPP__


### PR DESCRIPTION
include #6 
- implements disabling dns claiming
- use mac api calls to determine proper directories
- only dns_claim if sudo wasn't cancelled
- change `!` to `not` for readability