### PR TITLE
Use buildStats for 'paths built' metric

### DIFF
--- a/res/qml/ControlPanel.qml
+++ b/res/qml/ControlPanel.qml
@@ -174,9 +174,9 @@ ColumnLayout {
             }
 
             try {
-                numPathsBuilt = stats.result.services.default.numPaths;
+                numPathsBuilt = stats.result.services.default.buildStats.success;
             } catch (err) {
-                console.log("Couldn't pull services.numPaths out of payload", err);
+                console.log("Couldn't pull buildStats out of payload", err);
             }
         }
 


### PR DESCRIPTION
The previous metric was based on a parameter passed to `llarp::PathBuilder` which doesn't appear to be used, so it was effectively a hard-coded `3`