### PR TITLE
installer process detection

### DIFF
--- a/src/process/LokinetProcessManager.cpp
+++ b/src/process/LokinetProcessManager.cpp
@@ -8,6 +8,10 @@
 #include <memory>
 #include <mutex>
 
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
+
 using namespace std::literals::chrono_literals;
 
 constexpr auto MANAGED_KILL_WAIT = 5s;
@@ -18,6 +22,9 @@ LokinetProcessManager::LokinetProcessManager()
     : m_managedThreadRunning(false)
     , m_didLaunchProcess(false)
 {
+#ifdef Q_OS_WIN
+    ::CreateMutex(nullptr, FALSE, "lokinet_qt5_ui");
+#endif
 }
 
 LokinetProcessManager::~LokinetProcessManager()

--- a/src/process/LokinetProcessManager.cpp
+++ b/src/process/LokinetProcessManager.cpp
@@ -22,9 +22,6 @@ LokinetProcessManager::LokinetProcessManager()
     : m_managedThreadRunning(false)
     , m_didLaunchProcess(false)
 {
-#ifdef Q_OS_WIN
-    ::CreateMutex(nullptr, FALSE, "lokinet_qt5_ui");
-#endif
 }
 
 LokinetProcessManager::~LokinetProcessManager()
@@ -300,5 +297,8 @@ LinuxLokinetProcessManager g_processManager;
 
 LokinetProcessManager* LokinetProcessManager::instance()
 {
+#ifdef Q_OS_WIN
+    ::CreateMutex(nullptr, FALSE, "lokinet_qt5_ui");
+#endif
     return &g_processManager;
 }

--- a/src/process/LokinetProcessManager.cpp
+++ b/src/process/LokinetProcessManager.cpp
@@ -8,10 +8,6 @@
 #include <memory>
 #include <mutex>
 
-#ifdef Q_OS_WIN
-#include <windows.h>
-#endif
-
 using namespace std::literals::chrono_literals;
 
 constexpr auto MANAGED_KILL_WAIT = 5s;
@@ -297,8 +293,5 @@ LinuxLokinetProcessManager g_processManager;
 
 LokinetProcessManager* LokinetProcessManager::instance()
 {
-#ifdef Q_OS_WIN
-    ::CreateMutex(nullptr, FALSE, "lokinet_qt5_ui");
-#endif
     return &g_processManager;
 }

--- a/src/process/WindowsLokinetProcessManager.cpp
+++ b/src/process/WindowsLokinetProcessManager.cpp
@@ -26,7 +26,10 @@ bool WindowsLokinetProcessManager::doStartLokinetProcess()
     bool success = QProcess::startDetached(LOKINET_EXE_STR);
     if (! success)
     {
+        // when upgraded from old installations (before 0.5.x), lokinet.exe would be one
+        // directory higher
         success = QProcess::startDetached("..\\lokinet.exe");
+
         if (! success)
             qDebug("QProcess::startDetached() failed");
     }

--- a/src/process/WindowsLokinetProcessManager.cpp
+++ b/src/process/WindowsLokinetProcessManager.cpp
@@ -22,10 +22,15 @@ WindowsLokinetProcessManager::WindowsLokinetProcessManager()
 
 bool WindowsLokinetProcessManager::doStartLokinetProcess()
 {
+    // try searching one level up from CWD
     bool success = QProcess::startDetached(LOKINET_EXE_STR);
     if (! success)
-        qDebug("QProcess::startDetached() failed");
-
+    {
+        success = QProcess::startDetached("..\\lokinet.exe");
+        if (! success)
+            qDebug("QProcess::startDetached() failed");
+    }
+    
     return success;
 }
 

--- a/src/process/WindowsLokinetProcessManager.cpp
+++ b/src/process/WindowsLokinetProcessManager.cpp
@@ -15,6 +15,11 @@
 #define LOKINET_PATH LOKINET_DIR "\\lokinet.exe"
 #define LOKINET_EXE_STR "\"" LOKINET_PATH "\""
 
+WindowsLokinetProcessManager::WindowsLokinetProcessManager()
+{
+    ::CreateMutex(nullptr, FALSE, "lokinet_qt5_ui");
+}
+
 bool WindowsLokinetProcessManager::doStartLokinetProcess()
 {
     bool success = QProcess::startDetached(LOKINET_EXE_STR);

--- a/src/process/WindowsLokinetProcessManager.cpp
+++ b/src/process/WindowsLokinetProcessManager.cpp
@@ -11,13 +11,13 @@
 #include <tlhelp32.h>
 
 // TODO: don't hard-code these paths
-#define LOKINET_DIR "C:\\Program Files\\Loki Project\\Lokinet"
+#define LOKINET_DIR "C:\\Program Files\\Loki Project\\loki-network"
 #define LOKINET_PATH LOKINET_DIR "\\lokinet.exe"
 #define LOKINET_EXE_STR "\"" LOKINET_PATH "\""
 
 WindowsLokinetProcessManager::WindowsLokinetProcessManager()
 {
-    ::CreateMutex(nullptr, FALSE, "lokinet_qt5_ui");
+    ::CreateMutexA(nullptr, FALSE, "lokinet_qt5_ui");
 }
 
 bool WindowsLokinetProcessManager::doStartLokinetProcess()
@@ -91,7 +91,7 @@ bool WindowsLokinetProcessManager::doGetProcessPid(int& pid)
     return true;
 }
 
-QString getDefaultBootstrapFileLocation()
+QString WindowsLokinetProcessManager::getDefaultBootstrapFileLocation()
 {
     return QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
         + "\\AppData\\Roaming\\.lokinet\\bootstrap.signed";

--- a/src/process/WindowsLokinetProcessManager.cpp
+++ b/src/process/WindowsLokinetProcessManager.cpp
@@ -53,8 +53,10 @@ bool WindowsLokinetProcessManager::doStopLokinetProcess()
 
 bool WindowsLokinetProcessManager::doForciblyStopLokinetProcess()
 {
-    // cmd: taskkill /T /F /IM lokinet.exe
-    QStringList args = { "/T", "/F", "/IM", "lokinet.exe" };
+    // cmd: taskkill /F /PID [pid]
+    int p;
+    doGetProcessPid(p);
+    QStringList args = { "/F", "/PID", QString::number(p,10) };
     int result = QProcess::execute("taskkill", args);
     if (result)
     {

--- a/src/process/WindowsLokinetProcessManager.hpp
+++ b/src/process/WindowsLokinetProcessManager.hpp
@@ -14,6 +14,9 @@ class WindowsLokinetProcessManager : public LokinetProcessManager
 {
     Q_OBJECT
 
+public:
+    WindowsLokinetProcessManager();
+
 protected:
     
     bool doStartLokinetProcess() override;


### PR DESCRIPTION
the very existence of this mutex tells the lokinet for windows release installer to let the user know they need to exit the qt5 ui before continuing