### PR TITLE
Don't bother with graceful kill on Windows/Mac

### DIFF
--- a/src/process/LokinetProcessManager.cpp
+++ b/src/process/LokinetProcessManager.cpp
@@ -109,6 +109,17 @@ bool LokinetProcessManager::forciblyStopLokinetProcess()
 
 bool LokinetProcessManager::managedStopLokinetProcess()
 {
+    if (not isGracefulKillSupported())
+    {
+        qDebug("Platform doesn't support graceful kill, death will be swift and merciless");
+        if (not doForciblyStopLokinetProcess())
+        {
+            qDebug("doForciblyStopLokinetProcess() failed, good luck");
+            return false;
+        }
+        return true;
+    }
+
     std::lock_guard<std::mutex> guard(m_managedStopMutex);
 
     if (m_managedThreadRunning)

--- a/src/process/LokinetProcessManager.hpp
+++ b/src/process/LokinetProcessManager.hpp
@@ -137,9 +137,23 @@ protected:
      * Subclasses should provide platform-specific means of stopping the
      * lokinet process.
      *
+     * The return value should indicate whether the lokinet process was
+     * successfully told to stop, though it does not have to stop immediately.
+     *
      * @return true on success; false otherwise
      */
     virtual bool doStopLokinetProcess() = 0;
+
+    /**
+     * Subclasses should return whether or not the platform supports a graceful
+     * kill. A graceful kill would indicate that a non-forceful kill should
+     * successfully cause the lokinet process to terminate, though not necessarily
+     * immediately. If a graceful kill isn't supported, managedStopLokinetProcess()
+     * will immediately resort to a forceful kill.
+     *
+     * @return whether or not the platform supports a graceful kill
+     */
+    virtual bool isGracefulKillSupported() const { return true; };
     
     /**
      * Subclasses should provide platform-specific means of forcibly stopping

--- a/src/process/MacOSLokinetProcessManager.hpp
+++ b/src/process/MacOSLokinetProcessManager.hpp
@@ -22,6 +22,7 @@ protected:
 
     bool doStartLokinetProcess() override;
     bool doStopLokinetProcess() override;
+    bool isGracefulKillSupported() const override { return false; };
     bool doForciblyStopLokinetProcess() override;
     bool doGetProcessPid(int& pid) override;
 

--- a/src/process/WindowsLokinetProcessManager.hpp
+++ b/src/process/WindowsLokinetProcessManager.hpp
@@ -21,6 +21,7 @@ protected:
     
     bool doStartLokinetProcess() override;
     bool doStopLokinetProcess() override;
+    bool isGracefulKillSupported() const override { return false; };
     bool doForciblyStopLokinetProcess() override;
     bool doGetProcessPid(int& pid) override;
     QString getDefaultBootstrapFileLocation() override;


### PR DESCRIPTION
This avoids trying a graceful kill when it's not supported.

```diff
- Windows: not supported
- Mac: not supported
+ Linux: supported
```