### PR TITLE
Watchdog prototype

### DIFF
--- a/res/qml/ControlPanel.qml
+++ b/res/qml/ControlPanel.qml
@@ -63,14 +63,10 @@ ColumnLayout {
 
     Component.onCompleted: {
         stateApiPoller.statusAvailable.connect(handleStateResults);
-        stateApiPoller.pollImmediately();
-        stateApiPoller.setIntervalMs(500);
-        stateApiPoller.startPolling();
+        stateApiPoller.pollOnce();
 
         statusApiPoller.statusAvailable.connect(handleStatusResults);
-        statusApiPoller.pollImmediately();
-        statusApiPoller.setIntervalMs(500);
-        statusApiPoller.startPolling();
+        statusApiPoller.pollOnce();
 
     }
 
@@ -95,7 +91,7 @@ ColumnLayout {
 
     function handleStateResults(payload, error) {
         var stats = null;
-        
+
         if (! error) {
             try {
                 stats = JSON.parse(payload);
@@ -187,6 +183,7 @@ ColumnLayout {
         if (newRunning !== isRunning) isRunning = newRunning;
         if (newLokiAddress !== lokiAddress) lokiAddress = newLokiAddress;
         if (newNumRouters !== numRoutersKnown) numRoutersKnown = newNumRouters;
+        stateApiPoller.pollOnce();
     }
 
     function handleStatusResults(payload, error) {
@@ -197,7 +194,10 @@ ColumnLayout {
             } catch (err) {
                 console.log("Couldn't parse 'status' JSON-RPC payload", err);
             }
+        } else {
+            console.log('handleStatusResults error', error);
         }
+        statusApiPoller.pollOnce();
     }
 
     function queryVersion() {

--- a/src/ApiPoller.cpp
+++ b/src/ApiPoller.cpp
@@ -10,7 +10,9 @@ constexpr auto LOKI_DAEMON_URL = "http://localhost:1190/";
 ApiPoller::ApiPoller() {
     m_timer = new QTimer();
     m_timer->setInterval(DEFAULT_POLLING_INTERVAL_MS);
+    m_timer->setSingleShot(true);
     connect(m_timer, &QTimer::timeout, this, &ApiPoller::pollDaemon);
+    m_timeout_timer = nullptr;
 }
 
 // ApiPoller Destructor
@@ -53,6 +55,23 @@ void ApiPoller::pollImmediately() {
     QTimer::singleShot(0, this, &ApiPoller::pollDaemon);
 }
 
+// ApiPoller::pollOnce
+void ApiPoller::pollOnce() {
+    if (m_timeout_timer != nullptr) {
+        m_timeout_timer->stop();
+        delete m_timeout_timer;
+        m_timeout_timer = nullptr;
+    }
+
+    this->m_responded = false;
+    QTimer::singleShot(500, this, &ApiPoller::pollDaemon);
+    m_timeout_timer = new QTimer();
+    m_timeout_timer->setInterval(500 * 10);
+    m_timeout_timer->setSingleShot(true);
+    connect(m_timeout_timer, &QTimer::timeout, this, &ApiPoller::watchDog);
+    m_timeout_timer->start();
+}
+
 // ApiPoller::pollDaemon
 void ApiPoller::pollDaemon() {
     if (m_rpcPayload.empty()) {
@@ -61,6 +80,15 @@ void ApiPoller::pollDaemon() {
     }
     m_httpClient.postJson(LOKI_DAEMON_URL, m_rpcPayload, [=](QNetworkReply* reply) {
         static bool lastAttemptWasError = false;
+        if (m_timeout_timer != nullptr) {
+            m_timeout_timer->stop();
+            delete m_timeout_timer;
+            m_timeout_timer = nullptr;
+        }
+        if (this->m_responded) {
+            return;
+        }
+        this->m_responded = true;
         if (reply->error()) {
             if (! lastAttemptWasError) {
                 qDebug() << "JSON-RPC error: " << reply->error();
@@ -77,4 +105,17 @@ void ApiPoller::pollDaemon() {
             emit statusAvailable(reply->readAll(), reply->error());
         }
     });
+}
+
+void ApiPoller::watchDog() {
+    if (!this->m_responded) {
+        if (m_timeout_timer != nullptr) {
+            m_timeout_timer->stop();
+            delete m_timeout_timer;
+            m_timeout_timer = nullptr;
+        }
+        // needs to be before emit, because emit will call pollOnce which sets it
+        this->m_responded = true;
+        emit statusAvailable("", QNetworkReply::TimeoutError);
+    }
 }

--- a/src/ApiPoller.hpp
+++ b/src/ApiPoller.hpp
@@ -5,12 +5,12 @@
 #include <functional>
 #include <mutex>
 #include <string>
- 
+
 #include <QObject>
 #include <QTimer>
 
 #include "HttpClient.hpp"
- 
+
 /**
  * The ApiPoller periodically requests a JSON-RPC endpoint from the Loki daemon.
  */
@@ -56,9 +56,10 @@ public:
      * to fire its *timeout* signal. This does not affect periodic polling.
      */
     Q_INVOKABLE void pollImmediately();
+    Q_INVOKABLE void pollOnce();
 
 signals:
-    
+
     /**
      * Emitted when a JSON-RPC seponse containing new status information is
      * received from the server
@@ -75,10 +76,13 @@ private:
      * Poll the Loki daemon.
      */
     void pollDaemon();
+    void watchDog();
 
     QTimer* m_timer;
+    bool m_responded;
+    QTimer* m_timeout_timer;
     HttpClient m_httpClient;
     std::string m_rpcPayload;
 };
- 
+
 #endif // __LOKI_STAT_FETCHER_H__


### PR DESCRIPTION
This gets rid of the GUI thinking lokinet has exited when it has not. Basically ran into an issue where the non-singleShot timer would stop firing for unknown reasons. 

- adds `pollOnce()` which is like `pollImmediately()` but has a timeout watchdog associated.
- this now ensures that only one request (per subsystem) is in flight at a time, so if abyss can't keep up, it doesn't hose your TCP sockets (which was happening for me)
- added a lock to make sure in case the request comes in after the timeout we don't double dispatch
- this clearly fucks with the graph since they expect an entry every 500ms but I never got around to figuring out how the graphing works. Ideally a better algorithm (time integration/interpolation? I forget the exact term from gamedev) is needed.
- left `pollImmediately()` for library completeness

suggestions
- storing the `setIntervalMs()` as a property, so it's controllable via QML
- maybe an adjustable timeout for the future would be useful too

