### PR TITLE
Use lauchd to control process on MacOS

### DIFF
--- a/lokinet-gui.pro
+++ b/lokinet-gui.pro
@@ -26,7 +26,6 @@ HEADERS += src/QmlClipboardAdapter.hpp \
 RESOURCES += res/resources.qrc
 
 macx {
-    LIBS += -framework Security -framework CoreFoundation
     HEADERS += src/process/MacOSLokinetProcessManager.hpp
     SOURCES += src/process/MacOSLokinetProcessManager.cpp
     QT += svg

--- a/src/process/MacOSLokinetProcessManager.cpp
+++ b/src/process/MacOSLokinetProcessManager.cpp
@@ -4,156 +4,74 @@
 
 #include <QProcess>
 #include <QDebug>
+#include <QFile>
 
 #ifdef Q_OS_MACOS
 
-#include "CoreFoundation/CoreFoundation.h"
-#include "CoreFoundation/CFBundle.h"
-
-#include <sys/stat.h> // for stat()
-#include <libgen.h> // for dirname()
-#include <sys/param.h> // for MAXPATHLEN
-#include <unistd.h> // for getcwd()
-
-#define LOKINET_BINARY_NAME    "lokinet"
-
-// these paths are all relative to the app bundle root
-#define DNS_CLAIM_FILEPATH     "./dns_claim.sh"
-#define DNS_UNCLAIM_FILEPATH   "./dns_unclaim.sh"
-
-#define DISABLE_DNS_FILE       "/disable_auto_dns"
-
-std::string getExecutablePath() {
-    CFBundleRef mainBundle = CFBundleGetMainBundle();
-    CFURLRef executeablesURL = CFBundleCopyExecutableURL(mainBundle);
-    char path[PATH_MAX];
-    if (not CFURLGetFileSystemRepresentation(executeablesURL, TRUE, (UInt8 *)path, PATH_MAX))
-    {
-        qDebug("Couldn't getExecutablePath, good luck");
-    }
-    CFRelease(executeablesURL);
-    return std::string(dirname(path));
-}
-
-std::string getResourcesPath() {
-    CFBundleRef mainBundle = CFBundleGetMainBundle();
-    CFURLRef resourcesURL = CFBundleCopyResourcesDirectoryURL(mainBundle);
-    char path[PATH_MAX];
-    if (not CFURLGetFileSystemRepresentation(resourcesURL, TRUE, (UInt8 *)path, PATH_MAX))
-    {
-        qDebug("Couldn't getResourcesPath, good luck");
-    }
-    CFRelease(resourcesURL);
-
-    return std::string(path);
-}
-
-// utility to run a process as root
-// Note that 'args' should be NULL-terminated
-bool sudo(const std::string& cmd, const char* args[])
-{
-    // TODO: AuthorizationExecuteWithPrivileges is deprecated in favor of using
-    // AuthorizationServices
-
-    AuthorizationRef authorizationRef;
-    OSStatus status;
-    status = AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment,
-                                 kAuthorizationFlagDefaults, &authorizationRef);
-
-    FILE* pipe = NULL;
-    status = AuthorizationExecuteWithPrivileges(
-            authorizationRef,
-            cmd.c_str(),
-            kAuthorizationFlagDefaults,
-            (char *const  _Nonnull * _Nonnull)args,
-            &pipe);
-
-    return (status == errAuthorizationSuccess);
-}
-
-MacOSLokinetProcessManager::MacOSLokinetProcessManager()
-{
-    std::string dtd_path = getResourcesPath() + DISABLE_DNS_FILE;
-    qDebug() << "DNS Claim check: " << dtd_path.c_str();
-    struct stat buffer;
-    if (stat(dtd_path.c_str(), & buffer) == 0) {
-      qDebug("DNS Claim disabled");
-      m_dnsClaimEnabled = false;
-    } else {
-      qDebug("DNS Claim enabled");
-    }
-    std::string execPath = getExecutablePath();
-    chdir(execPath.c_str());
-    qDebug() << "Executable Path: " << execPath.c_str();
-}
-
-MacOSLokinetProcessManager::~MacOSLokinetProcessManager()
-{
-    if (m_dnsClaimed)
-    {
-        unclaimDNS();
-    }
-}
-
-bool MacOSLokinetProcessManager::claimDNS()
-{
-    if (not m_dnsClaimEnabled) return true;
-
-    char path[MAXPATHLEN];
-    getwd(path);
-    qDebug() << "Current Path: " << path;
-    int result = system(DNS_CLAIM_FILEPATH);
-    if (result)
-        qDebug() << "warning: failed to claim dns: " << result;
-    else
-        m_dnsClaimed = true;
-
-    return (result == 0);
-}
-
-bool MacOSLokinetProcessManager::unclaimDNS()
-{
-    if (not m_dnsClaimEnabled) return true;
-    int result = system(DNS_UNCLAIM_FILEPATH);
-    if (result)
-        qDebug() << "warning: failed to unclaim dns: " << result;
-    else
-        m_dnsClaimed = false;
-
-    return (result == 0);
-}
+// This magic file causes launchd to suspend management of lokinet.
+// Launchd will not automatically lauch lokinet so long as this file exists.
+//
+// However, it will not try to kill lokinet if it is already running when this
+// file is created, so to stop lokinet, we need to:
+// 1) create this file
+// 2) kill lokinet
+//
+// In order to start lokinet, we simply need to remove the file -- launchd will
+// immediately notice and spawn lokinet.
+constexpr auto suspendFile = "/var/lib/lokinet/suspend-launchd-service";
 
 bool MacOSLokinetProcessManager::doStartLokinetProcess()
 {
-    bool success = sudo(LOKINET_BINARY_NAME, NULL);
-    if (not success) {
-        qDebug("failed to launch lokinet via AuthorizationExecuteWithPrivileges");
-        return false;
+    // starting lokinet requires removal of our magicFile
+    QFile magicFile(suspendFile);
+    if (magicFile.exists()) {
+        qDebug() << "attempting to remove magic file " << suspendFile;
+        if (not magicFile.remove()) {
+            qDebug() << "Warning: failed to remove magic file " << suspendFile; 
+            return false;
+        } else {
+            return true;
+        }
+    } else {
+        qDebug() << "magic file " << suspendFile << " didn't exist, lokinet shouldn't be running";
+        return true;
+    }
+}
+
+bool MacOSLokinetProcessManager::doStopLokinetProcess()
+{
+    // starting lokinet requires creating our magicFile
+    QFile magicFile(suspendFile);
+    if (magicFile.exists()) {
+        qDebug() << "magic file " << suspendFile << " already exists, lokinet should not be running";
+    } else {
+        qDebug() << "no magic file " << suspendFile << ", attempting to create...";
+
+        // open() will attempt to create the file if it doesn't exist (when invoked in ReadWrite mode)
+        if (not magicFile.open(QIODevice::ReadWrite))
+        {
+            qDebug() << "failed to touch magic file " << suspendFile;
+            return false;
+        }
     }
 
-    success = claimDNS();
-    if (not success)
-        qDebug("dns claim failed");
-
-
-    return success;
+    // now that we have created our magic file, we need to kill lokinet (which we can do by
+    // simply delegating to our superclass)
+    return LokinetProcessManager::doStopLokinetProcess();
 }
 
 bool MacOSLokinetProcessManager::doForciblyStopLokinetProcess()
 {
-    const char* args[] = {"-9", LOKINET_BINARY_NAME, NULL};
-    bool success = sudo("/usr/bin/killall", args);
-    if (not success)
-        qDebug("failed to launch lokinet via AuthorizationExecuteWithPrivileges");
-
-    return success;
+    // TODO: we would need root privileges to do this. for now, just try the
+    //       graceful approach
+    return doStopLokinetProcess();
 }
 
 bool MacOSLokinetProcessManager::doGetProcessPid(int& pid)
 {
     QProcess proc;
     proc.setProgram("pgrep");
-    proc.setArguments({LOKINET_BINARY_NAME});
+    proc.setArguments({"^lokinet$"}); // strictly match lokinet, e.g. not lokinet-gui, etc.
     proc.start();
     bool success = proc.waitForFinished(5000);
     if (not success)

--- a/src/process/MacOSLokinetProcessManager.hpp
+++ b/src/process/MacOSLokinetProcessManager.hpp
@@ -14,23 +14,13 @@ class MacOSLokinetProcessManager : public LokinetProcessManager
 {
     Q_OBJECT
 
-public:
-    MacOSLokinetProcessManager();
-    ~MacOSLokinetProcessManager();
-
 protected:
 
     bool doStartLokinetProcess() override;
+    bool doStopLokinetProcess() override;
     bool doForciblyStopLokinetProcess() override;
     bool doGetProcessPid(int& pid) override;
 
-private:
-
-    bool claimDNS();
-    bool unclaimDNS();
-
-    bool m_dnsClaimEnabled = true;
-    bool m_dnsClaimed = false;
 };
 
 #endif // __LOKI_MACOS_LOKINET_PROCESS_MANAGER_HPP__


### PR DESCRIPTION
This controls the lokinet process by creating and removing a magic file
which is monitored by launchd and used to supress automatic launching of
lokinet when present.

Yes, this is pretty hacky, but... it's mac...