### PR TITLE
Bump macos target to 10.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13)  # Has to be set before `project()`, and ignored on non-macos
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)  # Has to be set before `project()`, and ignored on non-macos
 
 project(lokinet-gui
     VERSION 0.3.0


### PR DESCRIPTION
Raise deployment target to 10.15 to make the build work, because macox <10.15 doesn't properly support C++17.

We'll need to investigate compiling with real llvm to get something that works on earlier OS X versions, but for now this lets us make one that works in 10.15.