### PR TITLE
Qt5 + bionic build fixes

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,4 +1,4 @@
-local default_deps_base='libsystemd-dev qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qtquick-dialogs qml-module-qt-labs-platform qml-module-qtcharts libqt5charts5-dev liblokimq-dev';
+local default_deps_base='libsystemd-dev qtbase5-dev qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qtquick-dialogs qml-module-qt-labs-platform qml-module-qtcharts libqt5charts5-dev liblokimq-dev';
 local default_deps_nocxx=default_deps_base;
 local default_deps='g++ ' + default_deps_nocxx; // g++ sometimes needs replacement
 local default_windows_deps='mingw-w64-binutils mingw-w64-gcc mingw-w64-crt mingw-w64-headers mingw-w64-winpthreads perl openssh zip bash binutils'; // deps for windows cross compile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12)  # Has to be set before `project()`, and 
 project(lokinet-gui
     VERSION 0.3.0
     DESCRIPTION "Lokinet graphical control panel"
-    HOMEPAGE_URL https://github.com/loki-project/loki-network-control-panel
     LANGUAGES CXX)
 
 if(WIN32)


### PR DESCRIPTION
- qt5-default is no longer included in the latest qt5 packages on sid (and going away); update it to the base qt5 dev package.
- project(... HOMEPAGE_URL ...) broke the bionic build, removed it.