### PR TITLE
Condense UI elements to shrink the control panel

### DIFF
--- a/res/qml/AddressPanel.qml
+++ b/res/qml/AddressPanel.qml
@@ -8,7 +8,7 @@ import "."
 Container {
     property var address: ""
 
-    Layout.preferredHeight: 79
+    Layout.preferredHeight: 45
     Layout.preferredWidth: Style.appWidth
 
     contentItem: Rectangle {
@@ -24,7 +24,7 @@ Container {
         anchors.right: parent.right
         anchors.rightMargin: 20
 
-        y: 18
+        y: 3
         text: "Lokinet Address"
         font.family: Style.weakTextFont
         color: Style.weakTextColor
@@ -40,7 +40,7 @@ Container {
         anchors.right: parent.right
         anchors.rightMargin: 20
 
-        y: 40
+        y: 21
         text: address
         font.family: Style.weakTextFont
         color: Style.strongTextColor

--- a/res/qml/ConnectionButtonPanel.qml
+++ b/res/qml/ConnectionButtonPanel.qml
@@ -16,7 +16,7 @@ Container {
     onRunningChanged: updateState();
     onHoveringChanged: updateState();
 
-    Layout.preferredHeight: 198
+    Layout.preferredHeight: 168
     Layout.preferredWidth: Style.appWidth
 
     contentItem: Rectangle {

--- a/res/qml/ExitPanel.qml
+++ b/res/qml/ExitPanel.qml
@@ -11,7 +11,7 @@ Container {
   property var status: ""
   property var busy: false
   property var hasExit: false
-    Layout.preferredHeight: 200
+    Layout.preferredHeight: 167
     Layout.preferredWidth: Style.appWidth
 
     contentItem: Rectangle {
@@ -27,7 +27,7 @@ Container {
         anchors.right: parent.right
         anchors.rightMargin: 20
 
-        y: 18
+        y: 3
         text: "Exit Node"
         font.family: Style.weakTextFont
         color: Style.weakTextColor
@@ -45,7 +45,7 @@ Container {
         anchors.right: parent.right
         anchors.rightMargin: 20
 
-        y: 40
+        y: 25
         text: address
         font.family: Style.weakTextFont
         color: Style.strongTextColor
@@ -60,7 +60,7 @@ Container {
         anchors.right: parent.right
         anchors.rightMargin: 20
 
-        y: 80
+        y: 62
         text: "Auth Code"
         font.family: Style.weakTextFont
         color: Style.weakTextColor
@@ -79,7 +79,7 @@ Container {
         anchors.right: parent.right
         anchors.rightMargin: 20
 
-        y: 100
+        y: 82
         text: authcode
         font.family: Style.weakTextFont
         color: Style.strongTextColor
@@ -117,7 +117,7 @@ Container {
 
       }
 
-      y: 140
+      y: 112
       onClicked: {
         if(busy)
         {
@@ -187,7 +187,7 @@ Container {
       anchors.leftMargin: 20
       anchors.right: parent.right
       anchors.rightMargin: 20
-      y: 180
+      y: 150
       text: status
       font.family: Style.weakTextFont
       color: Style.weakTextColor

--- a/res/qml/RouteStatsPanel.qml
+++ b/res/qml/RouteStatsPanel.qml
@@ -10,21 +10,21 @@ Container {
     property var routers: 0
     property var buildRatio: ""
 
-    Layout.preferredHeight: 69
+    Layout.preferredHeight: 45
     Layout.preferredWidth: Style.appWidth
 
     contentItem: Rectangle {
         color: Style.panelBackgroundColor
     }
 
-    // "Paths built"
+    // "Active Paths"
     Text {
         anchors.left: parent.left
         anchors.leftMargin: 20
         anchors.right: parent.right
         anchors.rightMargin: 20
 
-        y: 18
+        y: 3
         text: "Active Paths"
         font.family: Style.weakTextFont
         color: Style.weakTextColor
@@ -37,7 +37,7 @@ Container {
         anchors.right: parent.right
         anchors.rightMargin: 20
 
-        y: 40
+        y: 22
         text: ""+ paths + " (" + buildRatio + " success)"
         font.family: Style.weakTextFont
         color: Style.strongTextColor
@@ -51,7 +51,7 @@ Container {
         anchors.right: parent.right
         anchors.rightMargin: 20
 
-        y: 18
+        y: 3
         text: "Lokinet routers"
         font.family: Style.weakTextFont
         color: Style.weakTextColor
@@ -64,7 +64,7 @@ Container {
         anchors.right: parent.right
         anchors.rightMargin: 20
 
-        y: 40
+        y: 22
         text: ""+ routers
         font.family: Style.weakTextFont
         color: Style.strongTextColor

--- a/res/qml/Style.qml
+++ b/res/qml/Style.qml
@@ -4,11 +4,11 @@ import QtQuick 2.0
 QtObject {
     readonly property color strongTextColor: "#efefef"
     readonly property string strongTextFont: "Roboto"
-    readonly property int strongTextSize: 11
+    readonly property int strongTextSize: 10
 
     readonly property color weakTextColor: "#6b6b78"
     readonly property string weakTextFont: "Roboto"
-    readonly property int weakTextSize: 11
+    readonly property int weakTextSize: 10
 
     readonly property color logoTextColor: "#eeefef"
     readonly property int logoTextSize: 24
@@ -29,5 +29,5 @@ QtObject {
     // app dimensions -- TODO: components should be sized dynamically,
     // this should either be defined/used in one place or implied by
     // the desired size of widgets
-    readonly property int appWidth: 340
+    readonly property int appWidth: 300
 }

--- a/res/qml/UsagePanel.qml
+++ b/res/qml/UsagePanel.qml
@@ -30,7 +30,7 @@ Container {
         recalculateGraphScale(chartData.getHighestSample());
     }
 
-    Layout.preferredHeight: 249
+    Layout.preferredHeight: 177
     Layout.preferredWidth: Style.appWidth
 
     contentItem: Rectangle {
@@ -75,7 +75,7 @@ Container {
         anchors.leftMargin: 20
         anchors.right: parent.right
         anchors.rightMargin: 20
-        y: 18
+        y: 3
         text: "Upload"
         font.family: Style.weakTextFont
         color: Style.weakTextColor
@@ -87,11 +87,12 @@ Container {
         anchors.leftMargin: 20
         anchors.right: parent.right
         anchors.rightMargin: 20
-        y: 40
+        y: 22
         text: ""+ makeRate(up)
         font.family: Style.weakTextFont
         color: Style.strongTextColor
         font.pointSize: Style.weakTextSize
+        z: 1
     }
 
     Text {
@@ -100,7 +101,7 @@ Container {
         anchors.right: parent.right
         anchors.rightMargin: 20
         text: "Download"
-        y: 18
+        y: 3
         font.family: Style.weakTextFont
         color: Style.weakTextColor
         font.pointSize: Style.weakTextSize
@@ -111,11 +112,12 @@ Container {
         anchors.leftMargin: 170
         anchors.right: parent.right
         anchors.rightMargin: 20
-        y: 40
+        y: 22
         text: ""+ makeRate(down)
         font.family: Style.weakTextFont
         color: Style.strongTextColor
         font.pointSize: Style.weakTextSize
+        z: 1
     }
 
   /*
@@ -161,8 +163,8 @@ Container {
         // these weird numbers come from an attempt to work around ChartView's
         // nasty permanent margins
         x: -20
-        y: 50
-        width: Style.appWidth + 20
+        y: 25
+        width: Style.appWidth + 75
         height: 189
 
         ValueAxis {


### PR DESCRIPTION
This should make it fit fine on a 720p screen.

These are taken on Linux at 100% scaling, but it should be comparable on other OSes:
| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/4459524/98760687-2f4e3880-23aa-11eb-84cc-ad617bc8ca2b.png) | ![image](https://user-images.githubusercontent.com/4459524/98760762-54db4200-23aa-11eb-8bd7-0cbb94a7abb5.png) |



